### PR TITLE
Prepare for crates.io publication

### DIFF
--- a/xrpicker-core/Cargo.toml
+++ b/xrpicker-core/Cargo.toml
@@ -1,11 +1,15 @@
-# SPDX-FileCopyrightText: 2022, Collabora, Ltd.
+# SPDX-FileCopyrightText: 2022-2023, Collabora, Ltd.
 # SPDX-License-Identifier: CC0-1.0
 
 [package]
+authors = ["Ryan Pavlik <ryan.pavlik@collabora.com>"]
+categories = ["config"]
+description = "Core functionality of enumerating OpenXR runtimes, identifying the active runtime, and updating the active runtime"
 edition = "2021"
 homepage = "https://github.com/rpavlik/xr-picker"
 license = "MIT OR Apache-2.0"
 name = "xrpicker"
+repository = "https://github.com/rpavlik/xr-picker"
 version = "2.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/xrpicker-core/README.md
+++ b/xrpicker-core/README.md
@@ -1,0 +1,31 @@
+# xrpicker crate
+
+<!--
+Copyright 2023, Collabora, Ltd.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+[![REUSE status](https://api.reuse.software/badge/github.com/rpavlik/xr-picker)](https://api.reuse.software/info/github.com/rpavlik/xr-picker)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](../CODE_OF_CONDUCT.md)
+
+This crate provides the core functionality for enumerating OpenXR runtimes,
+identifying the active runtime, and changing the active runtime, on Windows and
+Linux. It contains features that assist in implementing a GUI frontend but does
+not rely on or infer any particular GUI.
+
+See the
+[main XR Picker README](https://github.com/rpavlik/xr-picker/blob/main/README.md)
+for more information.
+
+## License
+
+Licensed under either of the
+[Apache License, Version 2.0](LICENSES/Apache-2.0.txt) or the
+[MIT license](LICENSES/MIT.txt) at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+
+This software conforms to the [REUSE specification](https://reuse.software).

--- a/xrpicker-gui/Cargo.toml
+++ b/xrpicker-gui/Cargo.toml
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: CC0-1.0
 
 [package]
-description = "Choose your active OpenXR runtime"
+authors = ["Ryan Pavlik <ryan.pavlik@collabora.com>"]
+description = "Choose your active OpenXR runtime in a friendly graphical interface"
 edition = "2021"
+homepage = "https://github.com/rpavlik/xr-picker"
 license = "MIT OR Apache-2.0"
 name = "xrpicker-gui"
+readme = "../README.md"
+repository = "https://github.com/rpavlik/xr-picker"
 version = "2.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/xrpicker-gui/Cargo.toml
+++ b/xrpicker-gui/Cargo.toml
@@ -16,7 +16,7 @@ version = "2.0.0"
 
 [dependencies]
 eframe = {version = "0.21.3", features = ["persistence"]}
-egui-winit = {version = "0.21.1", default-features = false, features = ["wayland"]}
+egui-winit = {version = "0.21.1", default-features = false}
 image = {version = "0.24.5", default-features = false, features = ["png"]}
 itertools = "0.10.5"
 rfd = "0.11.2"
@@ -25,6 +25,10 @@ xrpicker = {path = "../xrpicker-core"}
 # To add icon to EXE
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
+
+[target.'cfg(linux)'.dependencies]
+# Only need wayland support on linux
+egui-winit = {version = "0.21.1", default-features = false, features = ["wayland"]}
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2022-2023, Collabora, Ltd."


### PR DESCRIPTION
Could not publish as-is, due to some missing metadata, so add that metadata, along with a per-crate README.