### PR TITLE
Include license texts in the packaged crates

### DIFF
--- a/xrpicker-core/LICENSES
+++ b/xrpicker-core/LICENSES
@@ -1,0 +1,1 @@
+../LICENSES/

--- a/xrpicker-gui/LICENSES
+++ b/xrpicker-gui/LICENSES
@@ -1,0 +1,1 @@
+../LICENSES

--- a/xrpicker-gui/README.md
+++ b/xrpicker-gui/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
The MIT license requires the text to be included when distributing, this ensures the license files are always included in the packaged crates.